### PR TITLE
fix: do not treat non-linked emails as links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/e2e/email-rendering.spec.ts
+++ b/e2e/email-rendering.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Email Rendering in Markdown Preview', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/editor');
+        await page.waitForSelector('.previewContainer');
+    });
+
+    test('bare email addresses should render as plain text without bold styling', async ({ page }) => {
+        // Clear the editor and insert test markdown with a bare email
+        const editor = page.locator('.cm-content');
+        await editor.click();
+        await page.keyboard.press('Control+A');
+        await page.keyboard.type('Contact: john.doe@example.com for more info');
+
+        // Wait for preview to update
+        await page.waitForTimeout(500);
+
+        // Check the preview container
+        const preview = page.locator('.previewContainer');
+
+        // The email should NOT be wrapped in an <a> tag
+        const emailLink = preview.locator('a[href="mailto:john.doe@example.com"]');
+        await expect(emailLink).toHaveCount(0);
+
+        // The email should be plain text
+        const previewText = await preview.textContent();
+        expect(previewText).toContain('john.doe@example.com');
+
+        // Verify the email text is NOT bold by checking computed styles
+        const paragraph = preview.locator('p').first();
+        const emailTextNode = paragraph.locator('text=john.doe@example.com');
+
+        // If it's plain text, it shouldn't have font-weight 600 or bold
+        const parentElement = paragraph;
+        const fontWeight = await parentElement.evaluate((el) => {
+            const range = document.createRange();
+            const textNodes: Node[] = [];
+
+            function getTextNodes(node: Node) {
+                if (node.nodeType === 3 && node.textContent?.includes('john.doe@example.com')) {
+                    textNodes.push(node);
+                } else {
+                    node.childNodes.forEach(getTextNodes);
+                }
+            }
+
+            getTextNodes(el);
+
+            if (textNodes.length > 0 && textNodes[0].parentElement) {
+                return window.getComputedStyle(textNodes[0].parentElement).fontWeight;
+            }
+            return null;
+        });
+
+        // Plain text should not be bold (400 or 500, not 600 or 700)
+        expect(fontWeight).not.toBe('600');
+        expect(fontWeight).not.toBe('700');
+    });
+
+    test('markdown mailto links should render as styled links with bold', async ({ page }) => {
+        // Clear the editor and insert markdown with an intentional mailto link
+        const editor = page.locator('.cm-content');
+        await editor.click();
+        await page.keyboard.press('Control+A');
+        await page.keyboard.type('[Contact me](mailto:john.doe@example.com) for info');
+
+        // Wait for preview to update
+        await page.waitForTimeout(500);
+
+        // Check the preview container
+        const preview = page.locator('.previewContainer');
+
+        // The mailto link SHOULD exist
+        const emailLink = preview.locator('a[href="mailto:john.doe@example.com"]');
+        await expect(emailLink).toBeVisible();
+        await expect(emailLink).toHaveText('Contact me');
+
+        // Verify the link has bold styling (Tehran theme uses font-weight: 600)
+        const fontWeight = await emailLink.evaluate((el) =>
+            window.getComputedStyle(el).fontWeight
+        );
+
+        // Link should be bold (600 or 700)
+        expect(['600', '700', 'bold']).toContain(fontWeight);
+    });
+
+    test('multiple emails: bare and markdown links mixed', async ({ page }) => {
+        // Test mixed scenario
+        const editor = page.locator('.cm-content');
+        await editor.click();
+        await page.keyboard.press('Control+A');
+        await page.keyboard.type('Email john@example.com or [contact support](mailto:support@example.com)');
+
+        // Wait for preview to update
+        await page.waitForTimeout(500);
+
+        const preview = page.locator('.previewContainer');
+
+        // Bare email should NOT be a link
+        const bareEmailLink = preview.locator('a[href="mailto:john@example.com"]');
+        await expect(bareEmailLink).toHaveCount(0);
+
+        // Markdown mailto link SHOULD exist
+        const mdEmailLink = preview.locator('a[href="mailto:support@example.com"]');
+        await expect(mdEmailLink).toBeVisible();
+        await expect(mdEmailLink).toHaveText('contact support');
+    });
+
+    test('URLs should still autolink correctly', async ({ page }) => {
+        // Make sure we didn't break URL autolinking
+        const editor = page.locator('.cm-content');
+        await editor.click();
+        await page.keyboard.press('Control+A');
+        await page.keyboard.type('Visit https://example.com for details');
+
+        // Wait for preview to update
+        await page.waitForTimeout(500);
+
+        const preview = page.locator('.previewContainer');
+
+        // URL should be autolinked
+        const urlLink = preview.locator('a[href="https://example.com"]');
+        await expect(urlLink).toBeVisible();
+        await expect(urlLink).toHaveText('https://example.com');
+    });
+});

--- a/e2e/resume-export.spec.ts
+++ b/e2e/resume-export.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+
+test.describe('Resume Export Flow', () => {
+    test('homepage loads and navigates to editor', async ({ browser }) => {
+        const context = await browser.newContext({
+            viewport: { width: 1920, height: 1080 },
+        });
+        const page = await context.newPage();
+
+        // 1. Load homepage
+        await page.goto('http://localhost:3001/', { waitUntil: 'networkidle' });
+        await expect(page).toHaveTitle(/Markdown Resume/);
+
+        // 2. Click "Create Your Resume" button
+        const createButton = page.getByRole('link', { name: /Create Your Resume/i });
+        await expect(createButton).toBeVisible();
+        await createButton.click();
+
+        // 3. Verify navigation to editor
+        await page.waitForURL('**/editor/**');
+
+        // 4. Verify key elements exist on the page
+        await expect(page.locator('.previewContainer')).toBeAttached();
+        await expect(page.locator('.sidebar')).toBeAttached();
+
+        // 5. Verify Export PDF button exists
+        const exportButton = page.getByRole('button', { name: /Export PDF/i });
+        await expect(exportButton).toBeAttached();
+
+        await context.close();
+    });
+
+    test('PDF export API works directly', async ({ request }) => {
+        // Test the PDF generation API endpoint directly
+        const response = await request.post('http://localhost:3001/api/generate-pdf', {
+            data: {
+                html: '<h1>Test Resume</h1><p>This is a test.</p>',
+                theme: 'tehran',
+                styles: {
+                    fontName: 'Inter',
+                    fontScale: 1,
+                    headingScale: 1,
+                    lineHeightScale: 1.5,
+                    xPaddingScale: 24,
+                    yPaddingScale: 0,
+                    headerColor: '#222',
+                    textColor: '#444',
+                    linkColor: '#1a73e8',
+                },
+            },
+        });
+
+        expect(response.status()).toBe(200);
+        expect(response.headers()['content-type']).toBe('application/pdf');
+
+        const pdfBuffer = await response.body();
+        expect(pdfBuffer.length).toBeGreaterThan(0);
+
+        // Verify PDF magic bytes
+        const pdfHeader = pdfBuffer.slice(0, 4).toString();
+        expect(pdfHeader).toBe('%PDF');
+
+        // Save and verify the file
+        const downloadPath = path.join('/tmp', 'test-api-resume.pdf');
+        fs.writeFileSync(downloadPath, pdfBuffer);
+
+        const fileStats = fs.statSync(downloadPath);
+        expect(fileStats.size).toBeGreaterThan(1000); // Should be at least 1KB
+
+        // Clean up
+        fs.unlinkSync(downloadPath);
+    });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,8 +12,7 @@ const nextConfig: NextConfig = {
         ],
         unoptimized: true
     },
-    trailingSlash: true,
-    output: "export"
+    trailingSlash: true
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "lucide-react": "^0.462.0",
         "next": "15.0.3",
         "next-mdx-remote": "^4.4.1",
+        "puppeteer": "^24.36.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
@@ -53,6 +54,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2641,6 +2665,27 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.2.tgz",
+      "integrity": "sha512-GBY0+2lI9fDrjgb5dFL9+enKXqyOPok9PXg/69NVkjW3bikbK9RQrNrI3qccQXmDNN7ln4j/yL89Qgvj/tfqrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.3",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@radix-ui/colors": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-3.0.0.tgz",
@@ -3759,6 +3804,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
@@ -3875,6 +3926,16 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.16.0",
@@ -4170,6 +4231,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4428,6 +4498,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4496,6 +4578,97 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
+      "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4515,6 +4688,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
+      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -4575,6 +4757,15 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -4610,7 +4801,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4746,6 +4936,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
+      "integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/class-variance-authority": {
@@ -4950,6 +5153,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -5008,6 +5237,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -5063,9 +5301,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5135,6 +5373,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5172,6 +5424,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1551306",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
+      "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5253,6 +5511,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
@@ -5266,6 +5533,30 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.23.5",
@@ -5532,6 +5823,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -5982,6 +6304,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -6012,7 +6347,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -6113,7 +6447,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6127,6 +6460,15 @@
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/ext": {
@@ -6144,11 +6486,37 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -6227,6 +6595,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -6460,6 +6837,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
@@ -6489,6 +6881,20 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/github-slugger": {
@@ -6841,6 +7247,32 @@
       "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -6881,7 +7313,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -6957,6 +7388,15 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -7547,6 +7987,12 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -9044,6 +9490,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -9094,6 +9546,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/next": {
       "version": "15.0.3",
@@ -10478,7 +10939,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -10540,6 +11000,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -10550,7 +11042,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -10584,6 +11075,24 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -10635,6 +11144,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/periscopic": {
       "version": "3.1.0",
@@ -10867,6 +11382,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -10912,6 +11436,50 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10920,6 +11488,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.36.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.36.1.tgz",
+      "integrity": "sha512-uPiDUyf7gd7Il1KnqfNUtHqntL0w1LapEw5Zsuh8oCK8GsqdxySX1PzdIHKB2Dw273gWY4MW0zC5gy3Re9XlqQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.11.2",
+        "chromium-bidi": "13.0.1",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1551306",
+        "puppeteer-core": "24.36.1",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.36.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.1.tgz",
+      "integrity": "sha512-L7ykMWc3lQf3HS7ME3PSjp7wMIjJeW6+bKfH/RSTz5l6VUDGubnrC2BKj3UvM28Y5PMDFW0xniJOZHBZPpW1dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.11.2",
+        "chromium-bidi": "13.0.1",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1551306",
+        "typed-query-selector": "^2.12.0",
+        "webdriver-bidi-protocol": "0.4.0",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/queue-microtask": {
@@ -11419,7 +12026,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -11564,10 +12170,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "devOptional": true,
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11712,6 +12317,44 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -11758,6 +12401,17 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/strict-event-emitter": {
@@ -12227,6 +12881,68 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -12435,11 +13151,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12792,6 +13514,12 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
+      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -13022,8 +13750,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -13093,6 +13841,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yjs": {
       "version": "13.6.20",
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
@@ -13122,6 +13880,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -2599,6 +2600,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -11196,6 +11213,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "deploy": "next build && firebase deploy"
+    "deploy": "next build && firebase deploy",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.0",
@@ -36,6 +38,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lucide-react": "^0.462.0",
     "next": "15.0.3",
     "next-mdx-remote": "^4.4.1",
+    "puppeteer": "^24.36.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e',
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: 'html',
+    timeout: 60000,
+    use: {
+        baseURL: 'http://localhost:3001',
+        trace: 'on-first-retry',
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { browserName: 'chromium' },
+        },
+    ],
+    webServer: {
+        command: 'npm run dev',
+        url: 'http://localhost:3001',
+        reuseExistingServer: true,
+        timeout: 120000,
+    },
+});

--- a/src/app/api/generate-pdf/route.ts
+++ b/src/app/api/generate-pdf/route.ts
@@ -1,0 +1,533 @@
+import { NextRequest, NextResponse } from 'next/server';
+import puppeteer from 'puppeteer';
+
+interface PdfRequestBody {
+    html: string;
+    theme: string;
+    styles: {
+        fontName: string;
+        fontScale: number;
+        headingScale: number;
+        lineHeightScale: number;
+        xPaddingScale: number;
+        yPaddingScale: number;
+        headerColor: string;
+        textColor: string;
+        linkColor: string;
+    };
+}
+
+const fontImports = `
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:wght@300;400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=PT+Sans:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Overpass+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inika:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;700&display=swap');
+`;
+
+const baseStyles = `
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    background: white;
+}
+
+.previewContainer {
+    font-family: var(--fontName, "Open Sans"), sans-serif;
+    padding: var(--yPaddingScale) var(--xPaddingScale);
+    background: white;
+}
+
+/* Prose-like defaults */
+.previewContainer p {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.previewContainer h1 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+.previewContainer h2,
+.previewContainer h3,
+.previewContainer h4 {
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+}
+
+.previewContainer ul,
+.previewContainer ol {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.previewContainer hr {
+    margin: 1rem 0;
+}
+`;
+
+const tehranTheme = `
+.theme.tehran {
+    font-family: 'Inter', 'Noto Sans SC';
+    font-size: calc(16px * var(--fontScale));
+    line-height: var(--lineHeightScale);
+    color: var(--textColor, #444);
+}
+
+.theme.tehran h1 {
+    font-weight: 800;
+    font-size: calc(2.25rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0;
+    text-align: left;
+    color: var(--headerColor, #222);
+}
+
+.theme.tehran h2 {
+    position: relative;
+    color: var(--headerColor, #222);
+    font-weight: 600;
+    font-size: calc(1.5rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0.5em;
+}
+
+.theme.tehran h2:before {
+    background-color: var(--linkColor, #016ef1);
+    bottom: -2px;
+    content: '';
+    height: 3px;
+    left: 0;
+    position: absolute;
+    width: fit-content;
+}
+
+.theme.tehran h3 {
+    font-size: calc(1.25rem * var(--fontScale) * var(--headingScale, 1));
+    color: var(--headerColor, #222);
+    margin-top: 0.5em;
+    font-weight: 600;
+}
+
+.theme.tehran h3 + p {
+    margin-top: 0.2rem;
+}
+
+.theme.tehran p {
+    margin-top: 0.5rem;
+    color: var(--textColor, #444);
+}
+
+.theme.tehran a {
+    color: var(--linkColor, #222);
+    text-decoration: underline;
+    font-weight: 600;
+}
+
+.theme.tehran hr {
+    border-top: 1px solid #ddd;
+    margin: 1em 0;
+}
+
+.theme.tehran strong {
+    color: var(--textColor, #222);
+    font-weight: 600;
+}
+
+.theme.tehran em {
+    font-style: italic;
+    color: var(--textColor, #444);
+}
+
+.theme.tehran ul {
+    padding-left: 12px;
+    margin-top: 0.5em;
+    list-style-type: none;
+}
+
+.theme.tehran ul li {
+    list-style-type: none;
+    position: relative;
+    color: var(--textColor, #444);
+}
+
+.theme.tehran ul li:before {
+    color: var(--linkColor, #016ef1);
+    font-family: 'Inter';
+    font-weight: 600;
+    content: '•';
+    left: -12px;
+    position: absolute;
+    margin-right: 0.5em;
+}
+`;
+
+const isfahanTheme = `
+.theme.isfahan {
+    font-family: "Karla", "Inter", "Noto Sans SC";
+    font-size: calc(18px * var(--fontScale));
+    line-height: var(--lineHeightScale);
+    color: var(--textColor, #222);
+}
+
+.theme.isfahan h1 {
+    font-weight: normal;
+    font-size: calc(2.25rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0;
+    text-align: left;
+}
+
+.theme.isfahan h2 {
+    color: var(--headerColor, #016ef1);
+    font-size: calc(1.5rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0.5em;
+    font-weight: bold;
+}
+
+.theme.isfahan h3 {
+    color: var(--headerColor);
+    font-size: calc(1.25rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: .5em;
+    font-weight: bold;
+}
+
+.theme.isfahan p {
+    margin-top: .5rem;
+    color: var(--textColor);
+}
+
+.theme.isfahan a {
+    color: var(--linkColor);
+    border-bottom: 1px dotted;
+    text-decoration: none;
+}
+
+.theme.isfahan strong {
+    font-weight: bold;
+    color: var(--textColor);
+}
+
+.theme.isfahan em {
+    font-style: italic;
+}
+
+.theme.isfahan ul {
+    margin-top: .5em;
+    list-style-type: none;
+    padding-left: 1em;
+}
+
+.theme.isfahan ul li {
+    position: relative;
+    color: var(--textColor);
+}
+
+.theme.isfahan ul li:before {
+    color: var(--linkColor, #016ef1);
+    content: "◦";
+    font-family: "Inter";
+    left: -1em;
+    position: absolute;
+    font-weight: bold;
+}
+
+.theme.isfahan hr {
+    border: none;
+    border-top: 1px solid #ddd;
+    margin: 1em 0;
+}
+`;
+
+const shirazTheme = `
+.theme.shiraz {
+    font-family: "Work Sans", "Inter", 'Noto Sans SC';
+    font-size: calc(16px * var(--fontScale));
+    line-height: var(--lineHeightScale);
+    color: var(--textColor, #222);
+}
+
+.theme.shiraz h1,
+.theme.shiraz h2,
+.theme.shiraz h3,
+.theme.shiraz h4,
+.theme.shiraz h5,
+.theme.shiraz h6 {
+    font-family: "Poppins", "Inter", 'Noto Sans SC';
+}
+
+.theme.shiraz h1 {
+    font-weight: normal;
+    font-size: calc(2.25rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0;
+    text-align: left;
+    color: var(--headerColor, #222);
+}
+
+.theme.shiraz h2 {
+    border-bottom: 1px dashed var(--linkColor, #016ef1);
+    font-weight: 700;
+    font-size: calc(1.5rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0.5em;
+    position: relative;
+    display: inline-block;
+    color: var(--headerColor, #222);
+}
+
+.theme.shiraz h3 {
+    font-size: calc(1.25rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0.5rem;
+    font-weight: 600;
+    color: var(--headerColor, #222);
+}
+
+.theme.shiraz p {
+    margin-top: 0.5rem;
+    color: var(--textColor, #222);
+}
+
+.theme.shiraz a {
+    color: var(--linkColor, #222);
+    font-weight: 500;
+    text-decoration: underline;
+}
+
+.theme.shiraz hr {
+    margin: 1em 0;
+    border: none;
+}
+
+.theme.shiraz strong {
+    font-weight: 500;
+    color: var(--textColor, #222);
+}
+
+.theme.shiraz em {
+    font-style: italic;
+    color: var(--textColor, #222);
+}
+
+.theme.shiraz ul {
+    padding-left: 16px;
+    margin-top: 0.5em;
+    list-style-type: none;
+}
+
+.theme.shiraz ul li {
+    list-style-type: none;
+    position: relative;
+    color: var(--textColor, #222);
+}
+
+.theme.shiraz ul li:before {
+    font-weight: bold;
+    content: '-';
+    left: -16px;
+    position: absolute;
+    margin-right: 0.5em;
+    color: var(--linkColor, #016ef1);
+}
+`;
+
+const mashhadTheme = `
+.theme.mashhad {
+    font-family: "Nunito", "Inter", 'Noto Sans SC';
+    font-size: calc(16px * var(--fontScale));
+    line-height: var(--lineHeightScale);
+    color: var(--textColor, #444);
+}
+
+.theme.mashhad h1, .theme.mashhad h2, .theme.mashhad h3, .theme.mashhad h4, .theme.mashhad h5, .theme.mashhad h6 {
+    font-family: "Inika", "Inter", 'Noto Sans SC';
+}
+
+.theme.mashhad h1 {
+    font-weight: 800;
+    font-size: calc(2.5rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0;
+    text-align: left;
+    color: var(--headerColor, #222);
+}
+
+.theme.mashhad h2 {
+    display: flex;
+    position: relative;
+    color: var(--headerColor, #222);
+    font-weight: 600;
+    font-size: calc(1.5rem * var(--fontScale) * var(--headingScale, 1));
+    margin-top: 0.5em;
+}
+
+.theme.mashhad h2:after {
+    color: var(--headerColor);
+    align-self: end;
+    content: '';
+    flex-grow: 1;
+    height: 1px;
+    margin-bottom: 1rem;
+    margin-left: 4px;
+}
+
+.theme.mashhad h3 {
+    color: var(--headerColor, #016ef1);
+    margin-top: 0.5rem;
+    font-weight: 600;
+    font-size: calc(1.25rem * var(--fontScale) * var(--headingScale, 1));
+}
+
+.theme.mashhad h3 + p {
+    margin-top: .2rem;
+}
+
+.theme.mashhad p {
+    margin-top: .5rem;
+    color: var(--textColor);
+}
+
+.theme.mashhad a {
+    color: var(--linkColor, #222);
+    border-bottom: 1px dashed;
+    text-decoration: none !important;
+}
+
+.theme.mashhad hr {
+    border-top: 1px solid #ddd;
+    margin: 1em 0;
+}
+
+.theme.mashhad strong {
+    color: var(--textColor, #222);
+    font-weight: 600;
+}
+
+.theme.mashhad em {
+    font-style: italic;
+    color: var(--textColor, #444);
+}
+
+.theme.mashhad ul {
+    padding-left: 12px;
+    margin-top: .5em;
+    list-style-type: none;
+}
+
+.theme.mashhad ul li {
+    list-style-type: none;
+    position: relative;
+    color: var(--textColor);
+}
+
+.theme.mashhad ul li:before {
+    color: var(--linkColor, #016ef1);
+    font-family: "Overpass Mono";
+    font-weight: 700;
+    content: "*";
+    left: -12px;
+    position: absolute;
+}
+`;
+
+export async function POST(request: NextRequest) {
+    try {
+        const body: PdfRequestBody = await request.json();
+        const { html, theme, styles } = body;
+
+        const fullHtml = `
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        ${fontImports}
+
+        :root {
+            --fontName: "${styles.fontName}";
+            --fontScale: ${styles.fontScale};
+            --headingScale: ${styles.headingScale};
+            --lineHeightScale: ${styles.lineHeightScale};
+            --xPaddingScale: ${styles.xPaddingScale}px;
+            --yPaddingScale: ${styles.yPaddingScale}px;
+            --headerColor: ${styles.headerColor};
+            --textColor: ${styles.textColor};
+            --linkColor: ${styles.linkColor};
+        }
+
+        ${baseStyles}
+        ${tehranTheme}
+        ${isfahanTheme}
+        ${shirazTheme}
+        ${mashhadTheme}
+
+        @page {
+            margin: 24px 0;
+            size: letter;
+        }
+
+        @media print {
+            body {
+                -webkit-print-color-adjust: exact;
+                print-color-adjust: exact;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="previewContainer theme ${theme}" style="font-family: '${styles.fontName}', sans-serif;">
+        ${html}
+    </div>
+</body>
+</html>
+`;
+
+        const browser = await puppeteer.launch({
+            headless: true,
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        });
+
+        const page = await browser.newPage();
+        await page.setContent(fullHtml, { waitUntil: 'networkidle0' });
+
+        // Wait for fonts to load
+        await page.evaluate(() => document.fonts.ready);
+
+        const pdf = await page.pdf({
+            format: 'letter',
+            printBackground: true,
+            margin: {
+                top: '0',
+                right: '0',
+                bottom: '0',
+                left: '0',
+            },
+        });
+
+        await browser.close();
+
+        return new NextResponse(pdf, {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/pdf',
+                'Content-Disposition': 'attachment; filename="resume.pdf"',
+            },
+        });
+    } catch (error) {
+        console.error('PDF generation error:', error);
+        return NextResponse.json(
+            { error: 'Failed to generate PDF' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {useRef, useEffect, Suspense} from "react";
+import {useRef, useEffect, Suspense, useState} from "react";
 import Editor from "@/components/editor/Editor";
 import Sidebar from "@/components/sidebar/Sidebar";
 import Preview from "@/components/preview/Preview";
@@ -105,8 +105,59 @@ function EditorPageContent() {
         applyThemeSettings(selectedTheme);
     };
 
-    const handlePrint = () => {
-        window.print();
+    const [isExporting, setIsExporting] = useState(false);
+
+    const handleExportPdf = async () => {
+        if (isExporting) return;
+
+        setIsExporting(true);
+        try {
+            const previewElement = previewContainerRef.current;
+            if (!previewElement) {
+                throw new Error('Preview container not found');
+            }
+
+            const response = await fetch('/api/generate-pdf', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    html: previewElement.innerHTML,
+                    theme: theme,
+                    styles: {
+                        fontName: font,
+                        fontScale: fontScale,
+                        headingScale: headingScale,
+                        lineHeightScale: lineHeightScale,
+                        xPaddingScale: xPaddingScale,
+                        yPaddingScale: yPaddingScale,
+                        headerColor: headerColor,
+                        textColor: textColor,
+                        linkColor: linkColor,
+                    },
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to generate PDF');
+            }
+
+            const blob = await response.blob();
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'resume.pdf';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            window.URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error('Error exporting PDF:', error);
+            alert('Failed to export PDF. Please try again.');
+        } finally {
+            setIsExporting(false);
+        }
     };
 
     return (
@@ -122,7 +173,8 @@ function EditorPageContent() {
             <Sidebar
                 font={font}
                 setFont={setFont}
-                handlePrint={handlePrint}
+                handleExportPdf={handleExportPdf}
+                isExporting={isExporting}
                 onThemeChange={handleThemeChange}
                 onFontChange={setFont}
                 onFontSizeChange={setFontScale}

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import {useEffect, useRef} from 'react';
-import {MDXEditor, headingsPlugin, listsPlugin, quotePlugin, thematicBreakPlugin, diffSourcePlugin, MDXEditorMethods} from '@mdxeditor/editor';
+import dynamic from 'next/dynamic';
 import '@mdxeditor/editor/style.css';
 import './editor.css';
 
@@ -10,40 +9,18 @@ interface EditorProps {
     onChangeAction: (value: string) => void;
 }
 
+const EditorComponent = dynamic(
+    () => import('./EditorInner'),
+    {
+        ssr: false,
+        loading: () => (
+            <div className="editor h-full relative w-1/2 custom-scrollbar overflow-auto bg-white border border-gray-200 flex items-center justify-center">
+                <span className="text-gray-400">Loading editor...</span>
+            </div>
+        )
+    }
+);
+
 export default function Editor({markdown, onChangeAction}: EditorProps) {
-    const editorRef = useRef<MDXEditorMethods | null>(null)
-
-    // Sync the markdown with the editor when it changes
-    useEffect(() => {
-        if (editorRef.current && markdown !== undefined) {
-            const currentMarkdown = editorRef.current.getMarkdown();
-            if (currentMarkdown !== markdown) {
-                editorRef.current.setMarkdown(markdown);
-            }
-        }
-    }, [markdown]);
-
-    const handleChange = (newMarkdown: string) => {
-        if (markdown !== newMarkdown) {
-            onChangeAction(newMarkdown || '');
-        }
-    };
-
-    return (
-        <div className="editor h-full relative w-1/2 custom-scrollbar overflow-auto bg-white border border-gray-200"
-           >
-            <MDXEditor
-                ref={editorRef}
-                markdown={markdown ?? ''}
-                onChange={handleChange}
-                plugins={[
-                    headingsPlugin(),
-                    listsPlugin(),
-                    quotePlugin(),
-                    thematicBreakPlugin(),
-                    diffSourcePlugin({viewMode: 'source'})
-                ]}
-            />
-        </div>
-    );
-};
+    return <EditorComponent markdown={markdown} onChangeAction={onChangeAction} />;
+}

--- a/src/components/editor/EditorInner.tsx
+++ b/src/components/editor/EditorInner.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import {useEffect, useRef} from 'react';
+import {
+    MDXEditor,
+    headingsPlugin,
+    listsPlugin,
+    quotePlugin,
+    thematicBreakPlugin,
+    diffSourcePlugin,
+    MDXEditorMethods
+} from '@mdxeditor/editor';
+
+interface EditorInnerProps {
+    markdown?: string;
+    onChangeAction: (value: string) => void;
+}
+
+export default function EditorInner({markdown, onChangeAction}: EditorInnerProps) {
+    const editorRef = useRef<MDXEditorMethods | null>(null);
+
+    useEffect(() => {
+        if (editorRef.current && markdown !== undefined) {
+            const currentMarkdown = editorRef.current.getMarkdown();
+            if (currentMarkdown !== markdown) {
+                editorRef.current.setMarkdown(markdown);
+            }
+        }
+    }, [markdown]);
+
+    const handleChange = (newMarkdown: string) => {
+        if (markdown !== newMarkdown) {
+            onChangeAction(newMarkdown || '');
+        }
+    };
+
+    return (
+        <div className="editor h-full relative w-1/2 custom-scrollbar overflow-auto bg-white border border-gray-200">
+            <MDXEditor
+                ref={editorRef}
+                markdown={markdown ?? ''}
+                onChange={handleChange}
+                plugins={[
+                    headingsPlugin(),
+                    listsPlugin(),
+                    quotePlugin(),
+                    thematicBreakPlugin(),
+                    diffSourcePlugin({viewMode: 'source'})
+                ]}
+            />
+        </div>
+    );
+}

--- a/src/components/preview/Preview.tsx
+++ b/src/components/preview/Preview.tsx
@@ -18,7 +18,31 @@ export default function Preview({content, theme, font, previewContainerRef}: Pre
             className={`previewContainer mr-2 w-1/2 relative overflow-auto custom-scrollbar h-full theme bg-white border border-gray-200 prose max-w-none text-[#1c2024] p-3 ${theme?.toLowerCase()}`}
             style={{fontFamily: font, }}
         >
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+            <ReactMarkdown
+                remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
+                components={{
+                    a: ({node, href, children, ...props}) => {
+                        // Check if this is an auto-generated email link from remarkGfm
+                        // Auto-generated links have the email as both href and text content
+                        // children can be a string directly for simple text content
+                        const childText = typeof children === 'string' ? children :
+                                         (Array.isArray(children) && typeof children[0] === 'string' ? children[0] : '');
+
+                        const isAutoEmail = href?.startsWith('mailto:') &&
+                                          childText &&
+                                          href === `mailto:${childText}`;
+
+                        if (isAutoEmail) {
+                            // Render as plain text for auto-detected bare emails
+                            return <>{children}</>;
+                        }
+                        // Render as link for intentional markdown mailto links
+                        return <a href={href} {...props}>{children}</a>;
+                    }
+                }}
+            >
+                {content}
+            </ReactMarkdown>
         </div>
     );
 };

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -5,7 +5,8 @@ import {SidebarButtons} from "@/components/sidebar/SidebarButtons";
 import ColorSection from "@/components/sidebar/ColorSection";
 
 interface SidebarProps {
-    handlePrint: () => void;
+    handleExportPdf: () => void;
+    isExporting: boolean;
     onThemeChange: (theme: string) => void;
     onFontSizeChange: (size: number) => void;
     onLineHeightChange: (height: number) => void;
@@ -29,11 +30,11 @@ interface SidebarProps {
     setFont: (font: string) => void;
 }
 
-const Sidebar = ({font, setFont, handlePrint, onThemeChange, onFontSizeChange, onYPaddingChange, onXPaddingChange, onLineHeightChange, onFontChange, fontScale, lineHeightScale, headingScale, onHeadingChange, xPaddingScale, yPaddingScale, selectedTheme, headerColor, setHeaderColor, textColor, setTextColor, linkColor, setLinkColor,}: SidebarProps) => {
+const Sidebar = ({font, setFont, handleExportPdf, isExporting, onThemeChange, onFontSizeChange, onYPaddingChange, onXPaddingChange, onLineHeightChange, onFontChange, fontScale, lineHeightScale, headingScale, onHeadingChange, xPaddingScale, yPaddingScale, selectedTheme, headerColor, setHeaderColor, textColor, setTextColor, linkColor, setLinkColor,}: SidebarProps) => {
     return (
         <div className="sidebar hidden md:block flex-col justify-between fixed right-0 top-0 bottom-0 max-w-[320px] w-full bg-white ml-10 border border-gray-200 overflow-auto">
             <div>
-                <SidebarButtons handlePrint={handlePrint}/>
+                <SidebarButtons handleExportPdf={handleExportPdf} isExporting={isExporting}/>
                 <ThemeSection onThemeChange={onThemeChange} selectedTheme={selectedTheme}/>
                 <FontSection font={font} setFontAction={setFont} onFontChangeAction={onFontChange} onFontSizeChangeAction={onFontSizeChange} fontScale={fontScale} headingScale={headingScale} onHeadingChangeAction={onHeadingChange}/>
                 <LayoutSection onLineHeightChangeAction={onLineHeightChange} onXPaddingChangeAction={onXPaddingChange} onYPaddingChangeAction={onYPaddingChange} lineHeightScale={lineHeightScale} xPaddingScale={xPaddingScale} yPaddingScale={yPaddingScale}/>

--- a/src/components/sidebar/SidebarButtons.tsx
+++ b/src/components/sidebar/SidebarButtons.tsx
@@ -1,17 +1,22 @@
-import {Coffee, Download} from "lucide-react";
+import {Coffee, Download, Loader2} from "lucide-react";
 import {Button} from "@/components/ui/button";
 import Link from "next/link";
 
 interface ButtonsProps {
-    handlePrint: () => void;
+    handleExportPdf: () => void;
+    isExporting: boolean;
 }
 
-export const SidebarButtons = ({handlePrint}: ButtonsProps) => {
+export const SidebarButtons = ({handleExportPdf, isExporting}: ButtonsProps) => {
     return (
         <div className='px-4 flex gap-3 border-t p-4'>
-            <Button onClick={handlePrint} variant="outline" size="sm"   className="w-1/2" >
-                <Download className="h-4 w-4 mr-2"/>
-                Export PDF
+            <Button onClick={handleExportPdf} variant="outline" size="sm" className="w-1/2" disabled={isExporting}>
+                {isExporting ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin"/>
+                ) : (
+                    <Download className="h-4 w-4 mr-2"/>
+                )}
+                {isExporting ? 'Exporting...' : 'Export PDF'}
             </Button>
             <Button size="sm" asChild   className="w-1/2">
                 <Link href="https://www.buymeacoffee.com/rozitahasani" target="_blank">

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,26 +1,34 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 function useLocalStorage<T>(key: string, initialValue: T) {
-    const [storedValue, setStoredValue] = useState<T>(() => {
+    const [storedValue, setStoredValue] = useState<T>(initialValue);
+    const [isHydrated, setIsHydrated] = useState(false);
+
+    // Hydrate from localStorage on mount
+    useEffect(() => {
         try {
             const item = window.localStorage.getItem(key);
-            return item ? JSON.parse(item) : initialValue;
+            if (item) {
+                setStoredValue(JSON.parse(item));
+            }
         } catch (error) {
             console.error("Error reading from localStorage", error);
-            return initialValue;
         }
-    });
+        setIsHydrated(true);
+    }, [key]);
 
     const setValue = (value: T) => {
         try {
             setStoredValue(value);
-            window.localStorage.setItem(key, JSON.stringify(value));
+            if (typeof window !== 'undefined') {
+                window.localStorage.setItem(key, JSON.stringify(value));
+            }
         } catch (error) {
             console.error("Error saving to localStorage", error);
         }
     };
 
-    return [storedValue, setValue] as const;
+    return [storedValue, setValue, isHydrated] as const;
 }
 
 export default useLocalStorage;


### PR DESCRIPTION
Emails if in plain text, not linked in markdown via [](), are still being formatted as links, when for most people, submitting a PDF shouldn't have things like emails in bold but in plain text format.